### PR TITLE
added <linux/kernel.h> to cgroup_sock.c to include macro definition

### DIFF
--- a/src/cgroup_sock.c
+++ b/src/cgroup_sock.c
@@ -2,6 +2,7 @@
 #include <linux/bpf.h>
 #include <linux/if_link.h>
 #include <linux/limits.h>
+#include <linux/kernel.h>
 #include <net/if.h>
 #include <errno.h>
 #include <signal.h>


### PR DESCRIPTION
fixes #1 

I tested this fix on Fedora 33 and on an Ubuntu 20.10 vm and it compiles cleanly on both.